### PR TITLE
Fixed incorrect error logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function gulpWPpot (options) {
         this.push(potFile);
         done();
       } catch (error) {
-        done('error', new PluginError('gulp-wp-pot', error));
+        done(error, new PluginError('gulp-wp-pot', error));
       }
     }
   });


### PR DESCRIPTION
When passing 'error', only the string 'error' gets logged and makes debugging impossible. Passing the actual error object provides proper logs that can be debugged.